### PR TITLE
LIBFCREPO-1481. Added "sandbox" to the list of supported environments.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ dependencies = [
     "django>=4.2",
 ]
 authors = [
+    { name='University of Maryland Libraries', email='lib-ssdr@umd.edu' },
     { name="Peter Eichman", email="peichman@umd.edu" },
     { name="Tim Kanke", email="tkanke@umd.edu" },
 ]
@@ -19,4 +20,10 @@ classifiers = [
     "Framework :: Django",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: Apache Software License",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-django",
 ]

--- a/src/umd_lib_style/static/umd_lib_style/umd_lib_style.css
+++ b/src/umd_lib_style/static/umd_lib_style/umd_lib_style.css
@@ -194,6 +194,10 @@ Full header layout, with environment banner:
     background-color: green;
     color: white;
 }
+.sandbox.environment-banner {
+    background-color: tan;
+    color: black;
+}
 .test.environment-banner {
     background-color: #fff100;
     color: black;

--- a/src/umd_lib_style/templatetags/umd_lib_style.py
+++ b/src/umd_lib_style/templatetags/umd_lib_style.py
@@ -6,6 +6,7 @@ register = template.Library()
 
 ENVIRONMENT_LABELS = {
     'development': 'Local Environment',
+    'sandbox': 'Sandbox Environment',
     'test': 'Test Environment',
     'qa': 'QA Environment',
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def pytest_configure():
+    settings.configure()

--- a/tests/test_environment_banner.py
+++ b/tests/test_environment_banner.py
@@ -1,0 +1,36 @@
+import pytest
+
+from umd_lib_style.templatetags.umd_lib_style import environment_banner
+
+
+@pytest.mark.parametrize(
+    ('environment', 'expected_label'),
+    [
+        ('development', 'Local Environment'),
+        ('sandbox', 'Sandbox Environment'),
+        ('test', 'Test Environment'),
+        ('qa', 'QA Environment'),
+    ]
+)
+def test_environment_banner(settings, environment, expected_label):
+    settings.ENVIRONMENT = environment
+    html = environment_banner()
+    assert html == f'<div class="{environment} environment-banner">{expected_label}</div>'
+
+
+def test_production_environment(settings):
+    settings.ENVIRONMENT = 'production'
+    html = environment_banner()
+    assert html == ''
+
+
+def test_unknown_environment(settings):
+    settings.ENVIRONMENT = 'xanadu'
+    html = environment_banner()
+    assert html == ''
+
+
+def test_no_environment(settings):
+    settings.ENVIRONMENT = None
+    html = environment_banner()
+    assert html == ''


### PR DESCRIPTION
- Added tests for the environment_banner() tag
- Added pytest and pytest-django as optional dependencies in the group "test"

https://umd-dit.atlassian.net/browse/LIBFCREPO-1481